### PR TITLE
Correcció script de testvoc

### DIFF
--- a/dev/testvoc/bidix-unknowns.sh
+++ b/dev/testvoc/bidix-unknowns.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -e -u
+
+if [[ $# -eq 1 ]]; then
+    lang=$1
+    monodix=guess
+    bidix=guess
+    side=guess
+elif  [[ $# -eq 4 ]]; then
+    lang=$1
+    monodix=$2
+    bidix=$3
+    side=$4
+else
+    cat >&2 <<EOF
+Usage: $0 lang
+or:    $0 lang mono.dix bi.dix [r|l]
+
+Expands the analyser, and looks up all the bidix entries in the
+expanded analyser.
+
+For example, do \`$0 nno' in trunk/apertium-nno-nob/' to find
+nno-words that are in bidix but not the nno-analyser. If the source
+.dix files have a non-standard name, you can specify them in the
+second and third arguments, for example
+\`$0 eng ../apertium-eng_feil/apertium-eng.eng.dix apertium-eng-sco.eng-sco.dix l'
+(where \`l' means eng is the left-side of the bidix).
+EOF
+    exit 1
+fi
+
+
+if [[ ${monodix} = guess ]]; then
+    langdir=$(grep -m1 "^AP_SRC.*apertium-${lang}" config.log | sed "s/^[^=]*='//;s/'$//")
+    monodix=${langdir}/apertium-${lang}.${lang}.dix
+fi
+if [[ ${bidix} = guess ]]; then
+    basename=$(grep -m1 "^PACKAGE='apertium-" config.log | sed "s/^[^=]*='//;s/'$//")
+    pair=${basename##apertium-}
+    bidix=${basename}.${pair}.dix
+fi
+if [[ ${side} = guess ]]; then
+    if [[ ${lang} = ${pair%%-*} ]]; then
+        side=l
+    else
+        side=r
+    fi
+fi
+
+exp=$(mktemp -t bidix-unknowns.XXXXXXXX)
+trap 'rm -f "${exp}"' EXIT
+
+echo "Expanding monodix …" >&2
+lt-expand "${monodix}" \
+    | grep -ve __REGEXP__ \
+    | sed 's/[^:]*//; s/\(<.*>\)\(#.*\)/\2\1/' \
+    | LC_ALL=C sort -u >"${exp}"
+
+in_mono () {
+    # bidix has prefixes of monodix, have to use look instead of comm :-/
+    LC_ALL=C look "$1" "${exp}" >/dev/null
+}
+echo "Expanding bidix and checking for entries missing from monodix …" >&2
+lt-expand "${bidix}" \
+    | grep -ve __REGEXP__ \
+    | awk -vside="${side}" -F':|:[<>]:' '
+        BEGIN {
+          if(side=="l") {
+            nside=1
+            LR=":>:"
+            RL=":<:"
+          }
+          else {
+            nside=2
+            LR=":<:"            # flip it
+            RL=":>:"            # and reverse
+          }
+        }
+        # Make bidix match up with monodix (left=left, right=right):
+        /:>:/ { print LR $nside; next }
+        /:<:/ { print RL $nside; next }
+        /:/   { print ":"$nside }
+' \
+    | while read -r bientry; do
+          # Bidix now normalised to have the requested monodix on the "left"
+          case ${bientry} in
+              ":>:"* ) # If it's LR in bidix, then we check if unmarked / LR is in monodix
+                       in_mono "${bientry##:>}" || in_mono "${bientry}" || echo "${bientry}"
+                       ;;
+              ":<:"* ) # If it's RL in bidix, then we check if unmarked / RL is in monodix
+                       in_mono "${bientry##:<}" || in_mono "${bientry}" || echo "${bientry}"
+                       ;;
+              ":"* ) # If it's unmarked in bidix, then we check if unmarked / LR / RL in monodix
+                     in_mono "${bientry}" || in_mono ":>${bientry}" || in_mono ":<${bientry}" || echo "${bientry}"
+                     ;;
+              *) echo "ERROR: unexpected bientry format: ${bientry}" >&2;;
+          esac
+      done

--- a/dev/testvoc/inconsistency-summary.sh
+++ b/dev/testvoc/inconsistency-summary.sh
@@ -1,67 +1,43 @@
+#!/bin/bash
+
+IFS=","
 INC=$1
 PAIR=$2
 OUT=testvoc-summary.$PAIR.txt
-POS="abbr adj adv cm cnjadv cnjcoo cnjsub det guio ij n np num pr preadv prn rel vaux vbhaver vblex vbser vbmod"
+POS=($(grep -m 1 "^POS=" testvoc.conf | cut -d = -f 2))
+unset IFS
 
 echo -n "" > $OUT;
 
 date >> $OUT
-echo -e "===============================================" >> $OUT
+echo -e "================================================" >> $OUT
 echo -e "POS\tTotal\tClean\tWith @\tWith #\tClean %" >> $OUT
-for i in $POS; do
-	if [ "$i" = "det" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<n>' -e '<np>' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v -e '<n>' -e '<np>'  | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<n>' -e '<np>' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "preadv" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<adj>' -e '<adv>' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v -e '<adj>' -e '<adv>'  | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<adj>' -e '<adv>' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "adv" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<adj>' -e '<v' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v -e '<adj>' -e '<v' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<adj>' -e '<v' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "cnjsub" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<v' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v  -e '<v' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<v' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "prn" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<v' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v  -e '<v' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<v' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "vbhaver" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<pp' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v  -e '<pp' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<pp' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "vblex" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<adv' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v  -e '<adv' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<adv' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "pr" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<prn' -e '<ger' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v  -e '<prn' -e '<ger' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<prn' -e '<ger' | grep -v REGEX |  wc -l`;
-	elif [ "$i" = "rel" ]; then
-		TOTAL=`cat $INC | grep "<$i>" | grep -v -e '<pr' | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@' | grep -v  -e '<pr' | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v -e '<pr' | grep -v REGEX |  wc -l`;
+for i in "${!POS[@]}"; do
+	CONFIG=$(grep -m 1 "^Exclude_${POS[$i]}=" testvoc.conf | cut -d = -f 2)
+	if ! [ -z "$CONFIG" ]; then
+		CONFIG=$(sed "s/,/ -e /g" <<< $CONFIG)
+		ALL=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | grep -v -e $CONFIG);
+		TOTAL=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | grep -v -e $CONFIG | wc -l);
+		AT=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | grep -v -e $CONFIG | grep ' \\@' | wc -l);
+		HASH=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | grep -v -e $CONFIG | grep ' #' | wc -l);
 	else
-		TOTAL=`cat $INC | grep "<$i>" | grep -v REGEX | wc -l`; 
-		AT=`cat $INC | grep "<$i>" | grep '@'  | grep -v REGEX | wc -l`;
-		HASH=`cat $INC | grep "<$i>" | grep '>  *#' | grep -v REGEX |  wc -l`;
+		ALL=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX);
+		TOTAL=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | wc -l);
+		AT=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | grep ' \\@' | wc -l);
+		HASH=$(cat $INC | grep "<${POS[$i]}>" | grep -v REGEX | grep ' #' | wc -l);
 	fi
-	UNCLEAN=`calc $AT+$HASH`;
-	CLEAN=`calc $TOTAL-$UNCLEAN`;
-	PERCLEAN=`calc $UNCLEAN/$TOTAL*100 |sed 's/^\W*//g' | sed 's/~//g' | head -c 5`;
+	UNCLEAN=`bc <<< $AT+$HASH`;
+	CLEAN=`bc <<< $TOTAL-$UNCLEAN`;
+	PERCLEAN=`calc $UNCLEAN/$TOTAL*100 | sed 's/^\W*//g' | sed 's/~//g' | head -c 5`;
 	echo $PERCLEAN | grep "Err" > /dev/null;
 	if [ $? -eq 0 ]; then
 		TOTPERCLEAN="100";
 	else
-		TOTPERCLEAN=`calc 100-$PERCLEAN | sed 's/^\W*//g' | sed 's/~//g' | head -c 5`;
+		TOTPERCLEAN=`echo 100-$PERCLEAN | bc | sed 's/^\W*//g' | sed 's/~//g' | head -c 5`;
 	fi
 
-	echo -e $TOTAL";"$i";"$CLEAN";"$AT";"$HASH";"$TOTPERCLEAN;
+	if [ $TOTAL -gt 0 ]; then echo -e $TOTAL";"${POS[$i]}";"$CLEAN";"$AT";"$HASH";"$TOTPERCLEAN; fi
 done | sort -gr | awk -F';' '{print $2"\t"$1"\t"$3"\t"$4"\t"$5"\t"$6}' >> $OUT
 
-echo -e "===============================================" >> $OUT
+echo -e "================================================" >> $OUT
 cat $OUT;


### PR DESCRIPTION
Hola Hèctor,

T'envio les correccions perquè torni a funcionar el testvoc. Hi ha el que comento a la llista de correu i alguna actualització addicional:

1. Una versió nova de l'script `inconsistency-summary.sh`, més net i que utilitza el fitxer `testvoc.conf`.
2. Script `bidix-unknowns.sh`, necessari si vols utilitzar el paràmetre `-u`, que detecta les entrades que són al bidix però no al monodix (i que, per tant, no s'utilitzen).
3. Paràmetre `-t` per fer un testvoc sense "trim".

Espero que et resulti útil.